### PR TITLE
Handle the empty collection

### DIFF
--- a/src/com/BoxOfC/MDAG/MDAG.java
+++ b/src/com/BoxOfC/MDAG/MDAG.java
@@ -138,10 +138,13 @@ public class MDAG
         }
         /////
 
-        //Since we delay the minimization of the previously-added String
-        //until after we read the next one, we need to have a seperate
-        //statement to minimize the absolute last String.
-        replaceOrRegister(sourceNode, previousString);
+        if(strCollection.size() > 0)
+        {
+            //Since we delay the minimization of the previously-added String
+            //until after we read the next one, we need to have a seperate
+            //statement to minimize the absolute last String.
+            replaceOrRegister(sourceNode, previousString);
+        }
     }
     
     


### PR DESCRIPTION
If you don't do this, then an empty collection triggers an out of bounds exception at line 1 of `replaceOrRegister`. 
